### PR TITLE
chore: GENERATE_SOURCEMAP=false 윈도우 환경 지원

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "scripts": {
     "start": "GENERATE_SOURCEMAP=false react-scripts start",
+    "winStart": "set \"GENERATE_SOURCEMAP=false\" && react-scripts start",
     "build": "GENERATE_SOURCEMAP=false react-scripts build",
+    "winBuild": "set \"GENERATE_SOURCEMAP=false\" && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src/**/*.js",


### PR DESCRIPTION
### 변경 사항

- [x] "winStart": "set \"GENERATE_SOURCEMAP=false\" && react-scripts start",
- [x] "winBuild": "set \"GENERATE_SOURCEMAP=false\" && react-scripts build",

### 기타 사항
- npm run winStart 
- npm run winBuild

### 스크린샷
